### PR TITLE
Enable tracing_level_info on otel middleware

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -26,8 +26,13 @@ indexmap = "2.0.0"
 # environment variables; if unset, the exporters stay disabled and the binary
 # falls back to plain stdout logging.
 init-tracing-opentelemetry = { version = "0.37", features = ["otlp", "tracing_subscriber_ext", "tracer", "metrics", "logs", "tls-webpki-roots"] }
-axum-tracing-opentelemetry = "0.33"
-tonic-tracing-opentelemetry = "0.32"
+# tracing_level_info raises the middleware span level from TRACE to INFO.
+# Without it the inbound HTTP SERVER span is emitted at TRACE and the resource
+# attributes propagated through the OTel pipeline can suppress it under some
+# subscriber configurations. Upstream issue:
+# https://github.com/davidB/tracing-opentelemetry-instrumentation-sdk/issues/330
+axum-tracing-opentelemetry = { version = "0.33", features = ["tracing_level_info"] }
+tonic-tracing-opentelemetry = { version = "0.32", features = ["tracing_level_info"] }
 opentelemetry = "0.31"
 tower = "0.5"
 pyroscope = { version = "2.0", features = ["backend-pprof-rs"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -26,11 +26,6 @@ indexmap = "2.0.0"
 # environment variables; if unset, the exporters stay disabled and the binary
 # falls back to plain stdout logging.
 init-tracing-opentelemetry = { version = "0.37", features = ["otlp", "tracing_subscriber_ext", "tracer", "metrics", "logs", "tls-webpki-roots"] }
-# tracing_level_info raises the middleware span level from TRACE to INFO.
-# Without it the inbound HTTP SERVER span is emitted at TRACE and the resource
-# attributes propagated through the OTel pipeline can suppress it under some
-# subscriber configurations. Upstream issue:
-# https://github.com/davidB/tracing-opentelemetry-instrumentation-sdk/issues/330
 axum-tracing-opentelemetry = { version = "0.33", features = ["tracing_level_info"] }
 tonic-tracing-opentelemetry = { version = "0.32", features = ["tracing_level_info"] }
 opentelemetry = "0.31"


### PR DESCRIPTION
## Summary
Adds the `tracing_level_info` feature to both `axum-tracing-opentelemetry` and `tonic-tracing-opentelemetry`, raising the middleware-emitted span level from TRACE to INFO.

## Why
On the live cluster, the publisher's inbound HTTP SERVER span never reaches Tempo:

| service | INTERNAL | CLIENT | SERVER |
|---|---|---|---|
| seichi-game-data-publisher | ✅ | ✅ | **❌** |
| seichi-game-data-server | — | — | ✅ |

So traces always look like a single orphaned `<root span not yet received>` server span. That breaks publisher → server linkage in Grafana Explore Traces.

`set_parent` does not log a `SpanDisabled` warning, and `init-tracing-opentelemetry` already adds an `otel::tracing=trace` directive to the EnvFilter, so on paper level filtering should not drop the span. The upstream issue [#330](https://github.com/davidB/tracing-opentelemetry-instrumentation-sdk/issues/330) lands on enabling `tracing_level_info` as the working remedy regardless, and it's a low-risk Cargo flip (1 line per dep).

## Test plan
- [x] `cargo check` / `cargo fmt --check` / `cargo clippy` clean
- [ ] After deploy: confirm `traces_spanmetrics_calls_total{service="seichi-game-data-publisher",span_kind="SPAN_KIND_SERVER"}` becomes non-zero, and the same trace_id links publisher SERVER → publisher CLIENT → server SERVER spans in Tempo

🤖 Generated with [Claude Code](https://claude.com/claude-code)