### PR TITLE
Drop OtelInResponseLayer

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -465,7 +465,7 @@ mod app {
     use crate::infra_repository_impls;
     use crate::profiler;
     use axum::Router;
-    use axum_tracing_opentelemetry::middleware::{OtelAxumLayer, OtelInResponseLayer};
+    use axum_tracing_opentelemetry::middleware::OtelAxumLayer;
     use std::sync::Arc;
 
     pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -500,7 +500,6 @@ mod app {
 
         let routes: Router = Router::new()
             .route("/metrics", infra_axum_handlers::handle_get_metrics())
-            .layer(OtelInResponseLayer)
             .layer(OtelAxumLayer::default())
             .with_state(shared_state.clone());
 


### PR DESCRIPTION
## Summary
Removes `OtelInResponseLayer` from the axum router.

## Note (post-merge correction)
This PR was originally proposed and merged with the assumption that `OtelInResponseLayer` was the cause of missing publisher SERVER spans in Tempo. **That assumption was wrong.** Subsequent investigation showed the real cause was OTLP/gRPC export batches exceeding Tempo's default 4 MiB receive limit — a transport-layer issue, not a middleware-stack one. SERVER spans were occasionally reaching Tempo all along (~15/24h confirmed in spanmetrics).

The change itself is being kept because:
- the response `traceparent` header that this layer injected was never consumed by any caller in the cluster
- removing it is a structural simplification with no observed downside

In other words: the right outcome (drop a layer we don't use) for the wrong reason. Kept; not reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)