### PR TITLE
Document tracing_level_info as an operational level choice

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -26,6 +26,8 @@ indexmap = "2.0.0"
 # environment variables; if unset, the exporters stay disabled and the binary
 # falls back to plain stdout logging.
 init-tracing-opentelemetry = { version = "0.37", features = ["otlp", "tracing_subscriber_ext", "tracer", "metrics", "logs", "tls-webpki-roots"] }
+# tracing_level_info: emit OTel middleware spans at INFO instead of TRACE,
+# matching the default RUST_LOG=info under which this service runs.
 axum-tracing-opentelemetry = { version = "0.33", features = ["tracing_level_info"] }
 tonic-tracing-opentelemetry = { version = "0.32", features = ["tracing_level_info"] }
 opentelemetry = "0.31"


### PR DESCRIPTION
## Summary
Adds a one-liner above the otel middleware deps explaining that `tracing_level_info` is enabled to keep middleware spans at INFO, matching our default `RUST_LOG=info`.

## Why
The original PR (#163) framed this feature as the fix for missing publisher SERVER spans in Tempo. The real cause was identified later as OTLP/gRPC batches exceeding Tempo's 4 MiB receive limit (`ResourceExhausted` from the alloy-receiver exporter, `error_permanent=true`). The feature flip itself is still desirable as a level-policy choice, but it isn't the cure for span loss. Adding the comment so future readers don't misread the intent.

## Test plan
- [x] `cargo check` clean (verified locally)
- No runtime behaviour change

🤖 Generated with [Claude Code](https://claude.com/claude-code)