### PR TITLE
Stop Debug-formatting large args via tracing::instrument

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -92,7 +92,7 @@ mod use_cases {
     }
 
     impl GetAllPlayerDataUseCase {
-        #[tracing::instrument]
+        #[tracing::instrument(skip(self))]
         pub async fn get_all_known_aggregated_player_data(
             &self,
         ) -> anyhow::Result<KnownAggregatedPlayerData> {
@@ -170,7 +170,7 @@ mod infra_axum_handlers {
             ))?)
         }
 
-        #[tracing::instrument]
+        #[tracing::instrument(skip(data), fields(player_count = data.0.len()))]
         pub fn present_player_data_as_prometheus_metrics(
             data: &KnownAggregatedPlayerData,
         ) -> anyhow::Result<String> {
@@ -201,7 +201,7 @@ mod infra_axum_handlers {
     /// Handler for the `GET /metrics` endpoint.
     pub fn handle_get_metrics() -> MethodRouter<SharedAppState> {
         // we need a separate handler function to create an error tracing span
-        #[tracing::instrument]
+        #[tracing::instrument(skip(state))]
         async fn handle_request(state: &SharedAppState) -> Response {
             let use_case = GetAllPlayerDataUseCase {
                 repository: state.repository.clone(),
@@ -314,7 +314,7 @@ mod infra_repository_impls {
     }
 
     impl GameDataGrpcRepository {
-        #[tracing::instrument]
+        #[tracing::instrument(skip(config), fields(endpoint = %config.game_data_server_grpc_endpoint_url))]
         pub async fn initialize_connections_with(
             config: config::GrpcClient,
         ) -> anyhow::Result<Self> {
@@ -345,7 +345,7 @@ mod infra_repository_impls {
 
     #[async_trait::async_trait]
     impl crate::domain::PlayerDataRepository for GameDataGrpcRepository {
-        #[tracing::instrument]
+        #[tracing::instrument(skip(self))]
         async fn get_all_break_counts(&self) -> anyhow::Result<Vec<PlayerBreakCount>> {
             Ok(self
                 .game_data_client()
@@ -358,7 +358,7 @@ mod infra_repository_impls {
                 .collect::<Result<_, _>>()?)
         }
 
-        #[tracing::instrument]
+        #[tracing::instrument(skip(self))]
         async fn get_all_build_counts(&self) -> anyhow::Result<Vec<PlayerBuildCount>> {
             Ok(self
                 .game_data_client()
@@ -371,7 +371,7 @@ mod infra_repository_impls {
                 .collect::<Result<_, _>>()?)
         }
 
-        #[tracing::instrument]
+        #[tracing::instrument(skip(self))]
         async fn get_all_play_ticks(&self) -> anyhow::Result<Vec<PlayerPlayTicks>> {
             Ok(self
                 .game_data_client()
@@ -384,7 +384,7 @@ mod infra_repository_impls {
                 .collect::<Result<_, _>>()?)
         }
 
-        #[tracing::instrument]
+        #[tracing::instrument(skip(self))]
         async fn get_all_vote_counts(&self) -> anyhow::Result<Vec<PlayerVoteCount>> {
             Ok(self
                 .game_data_client()


### PR DESCRIPTION
## Summary
Adds `skip(...)` to the remaining `#[tracing::instrument]` annotations that were Debug-formatting heavy arguments into span fields.

| location | change |
|---|---|
| `present_player_data_as_prometheus_metrics(data)` | `skip(data), fields(player_count = data.0.len())` |
| `handle_request(state)` | `skip(state)` |
| `get_all_known_aggregated_player_data(&self)` | `skip(self)` |
| `get_all_{break,build,play,vote}_counts(&self)` | `skip(self)` |
| `initialize_connections_with(config)` | `skip(config), fields(endpoint = …)` |

`skip(self)` is preferred over `skip_all` so any future argument is recorded by default.

## Why
Tempo's stored trace [`9560165f7c779f4d6e5435a54387aa9`](https://grafana.onp-k8s.admin.seichi.click/explore?...) shows `present_player_data_as_prometheus_metrics`'s span carrying `data = "KnownAggregatedPlayerData({Player ..."` — i.e. the full ~55,000-entry IndexMap was being Debug-rendered into the span field. Pyroscope on `seichi-game-data-publisher` confirms CPU is dominated by `Attributes::record`, `<&T as Debug>::fmt`, `format_inner`, `DebugStruct::field` — the recording cost of those arguments.

The same pattern appears at lower amplitude on `handle_request(state)` and the repository methods (each receives `self` whose Debug includes the full repository / gRPC channel state on every call).

## Expected effect
Publisher CPU and `/metrics` latency should both drop meaningfully. The magnitude is left for post-deploy measurement (Pyroscope flame graph + a fresh trace's `present_player_data_as_prometheus_metrics` busy/idle ns) — earlier predictions were tighter than the available evidence supported.

## Follow-ups (not in this PR)
- `write_record` calls `format!` per record, building a temp `String` ~220k times per scrape. After this PR's allocations stop dominating, that becomes the next likely hotspot. Switching to `write!(target, "...")` should be cheap.
- Server side is currently I/O bound (90% in sqlx row streaming). Larger-scale options later: collapse 4 RPCs into one, cache, or move metric exposition into the server.

## Test plan
- [x] `cargo check` / `cargo fmt --check` / `cargo clippy` clean
- [ ] Post-deploy: trace duration of `present_player_data_as_prometheus_metrics` drops; Pyroscope no longer shows `format_inner` / `Attributes::record` as the top frame; CFS throttle (currently ~12.6 %) drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)